### PR TITLE
fix: add INVALID opcode

### DIFF
--- a/src/ERC4337Checker.sol
+++ b/src/ERC4337Checker.sol
@@ -464,7 +464,8 @@ contract ERC4337Checker {
             || opcode == 0x5A // GAS
             || opcode == 0xF0 // CREATE
             || opcode == 0x41 // COINBASE
-            || opcode == 0xFF; // SELFDESTRUCT
+            || opcode == 0xFF // SELFDESTRUCT
+            || opcode == 0xFE; // INVALID
     }
 
     function isValidNextOpcodeOfGas(uint8 nextOpcode) private pure returns (bool) {


### PR DESCRIPTION
When this opcode is encountered:
* Execution stops immediately
* All remaining gas in the current call frame is burned

This provides a potent DoS vector against bundlers.