### PR TITLE
feat: op-032 from ERC 7562 spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docs/
 
 # Dotenv file
 .env
+
+.vscode

--- a/test/ERC4337Checker.t.sol
+++ b/test/ERC4337Checker.t.sol
@@ -187,6 +187,25 @@ contract ERC4337CheckerTest is Test {
         checker.printFailureLogs();
     }
 
+    function test_forbiddenOpCodeCreate() public {
+        address mockAccountAddr = address(mockAccount);
+
+        bytes memory encodedCallData = abi.encodeWithSelector(
+            MockAccount.execute.selector,
+            MockAccount.AttackType.FORBIDDEN_OPCODE_CREATE
+        );
+
+        UserOperation memory userOp = _getUnsignedOp(
+            mockAccountAddr,
+            encodedCallData
+        );
+
+        assertFalse(
+            checker.simulateAndVerifyUserOp(vm, userOp, entryPoint)
+        );
+        checker.printFailureLogs();
+    }
+
     function test_outOfGas() public {
         address mockAccountAddr = address(mockAccount);
 

--- a/test/mocks/MockAccount.sol
+++ b/test/mocks/MockAccount.sol
@@ -40,7 +40,8 @@ contract MockAccount is BaseAccount {
         FORBIDDEN_OPCODE_GASLIMIT,
         FORBIDDEN_OPCODE_COINBASE,
         FORBIDDEN_OPCODE_ORIGIN,
-        FORBIDDEN_OPCODE_INVALID
+        FORBIDDEN_OPCODE_INVALID,
+        FORBIDDEN_OPCODE_CREATE
     }
 
     IEntryPoint private _entryPoint;
@@ -113,6 +114,10 @@ contract MockAccount is BaseAccount {
                 // The invalid opcode was executed and caught
                 console2.log("Invalid opcode caught in try-catch");
             }
+        } else if (attackType == AttackType.FORBIDDEN_OPCODE_CREATE){
+            address demoAddress = address(new InvalidActions());
+            console2.log("New contract", demoAddress);
+
         }
 
         return 0;


### PR DESCRIPTION
- Added validation to forbid CREATE opcode when factory is NOT present
- Restrict CREATE execution to sender contract only (no utility contracts)